### PR TITLE
fix: Scopes values fix.

### DIFF
--- a/src/main/java/it/pagopa/swclient/mil/azureservices/identity/bean/Scope.java
+++ b/src/main/java/it/pagopa/swclient/mil/azureservices/identity/bean/Scope.java
@@ -5,6 +5,8 @@
  */
 package it.pagopa.swclient.mil.azureservices.identity.bean;
 
+import java.util.Map;
+
 /**
  * <p>
  * Scopes of access tokens.
@@ -18,21 +20,57 @@ public class Scope {
 	 * Scope to get an access token to access to Key Vault APIs.
 	 * </p>
 	 */
-	public static final String VAULT = "https://vault.azure.net/.default";
+	public static final String VAULT = "https://vault.azure.net";
 
 	/**
 	 * <p>
 	 * Scope to get an access token to access to Storage Account APIs.
 	 * </p>
 	 */
-	public static final String STORAGE = "https://storage.azure.com/.default";
+	public static final String STORAGE = "https://storage.azure.com";
 
 	/**
 	 * <p>
-	 * This class contains constants only.
+	 * Scope to get an access token to access to Key Vault APIs by means of Workload Identity.
+	 * </p>
+	 */
+	public static final String VAULT_WORKLOAD_IDENTITY = "https://vault.azure.net/.default";
+
+	/**
+	 * <p>
+	 * Scope to get an access token to access to Storage Account APIs by means of Workload Identity.
+	 * </p>
+	 */
+	public static final String STORAGE_WORKLOAD_IDENTITY = "https://storage.azure.com/.default";
+
+	/**
+	 * <p>
+	 * Mapping between scope values required by System Managed Identity and value required by Workload
+	 * Identity.
+	 * </p>
+	 */
+	private static final Map<String, String> FOR_WORKLOAD_IDENTITY = Map.of(
+		VAULT, VAULT_WORKLOAD_IDENTITY,
+		STORAGE, STORAGE_WORKLOAD_IDENTITY);
+
+	/**
+	 * <p>
+	 * Maps the scope value required by System Managed Identity to value required by Workload Identity.
+	 * </p>
+	 * 
+	 * @param scope Scope to be mapped to value required by Workload Identity.
+	 * @return Value required by Workload Identity.
+	 */
+	public static String getForWorkloadIdentity(String scope) {
+		return FOR_WORKLOAD_IDENTITY.getOrDefault(scope, scope);
+	}
+
+	/**
+	 * <p>
+	 * This class contains static stuff only.
 	 * </p>
 	 */
 	private Scope() {
-		// This class contains constants only.
+		// This class contains static stuff only.
 	}
 }

--- a/src/main/java/it/pagopa/swclient/mil/azureservices/identity/client/workload/AzureWorkloadIdentityClient.java
+++ b/src/main/java/it/pagopa/swclient/mil/azureservices/identity/client/workload/AzureWorkloadIdentityClient.java
@@ -14,6 +14,7 @@ import io.quarkus.logging.Log;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.swclient.mil.azureservices.identity.bean.AccessToken;
+import it.pagopa.swclient.mil.azureservices.identity.bean.Scope;
 import it.pagopa.swclient.mil.azureservices.identity.client.AzureIdentityClient;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -60,6 +61,6 @@ public class AzureWorkloadIdentityClient implements AzureIdentityClient {
 	@Override
 	public Uni<AccessToken> getAccessToken(String scope) {
 		Log.tracef("Get access token with Workload Identity for %s", scope);
-		return restClient.getAccessToken(scope);
+		return restClient.getAccessToken(Scope.getForWorkloadIdentity(scope));
 	}
 }

--- a/src/test/java/it/pagopa/swclient/mil/azureservices/identity/client/workload/AzureWorkloadIdentityClientTest.java
+++ b/src/test/java/it/pagopa/swclient/mil/azureservices/identity/client/workload/AzureWorkloadIdentityClientTest.java
@@ -59,7 +59,7 @@ class AzureWorkloadIdentityClientTest {
 			.setValue("access_token_string");
 
 		AzureWorkloadIdentityRestClient restClient = mock(AzureWorkloadIdentityRestClient.class);
-		when(restClient.getAccessToken(Scope.STORAGE))
+		when(restClient.getAccessToken(Scope.getForWorkloadIdentity(Scope.STORAGE)))
 			.thenReturn(Uni.createFrom()
 				.item(accessToken));
 


### PR DESCRIPTION
The values of scopes required by Microsoft Entra ID, for the same resource, are different depending on the usage of System Managed Identity or Workload Identity!

With this fix the two worlds are put into agreement!